### PR TITLE
Add R dotkit support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+tests/

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -2,5 +2,6 @@
     "profile_name": "broad-uger",
     "cluster_name": "UGER",
     "immediate_submit": false,
-    "conda_env": "snakemake"
+    "conda_env": "snakemake",
+    "dotkits": "Anaconda3 R-3.2"
 }

--- a/{{ cookiecutter.profile_name }}/broad-jobscript.sh
+++ b/{{ cookiecutter.profile_name }}/broad-jobscript.sh
@@ -4,7 +4,7 @@
 
 source /broad/software/scripts/useuse
 use {{ cookiecutter.cluster_name }}
-use .anaconda3-5.0.3
+use {{ cookiecutter.dotkits }} 
 
 source activate {{ cookiecutter.conda_env }}
 

--- a/{{ cookiecutter.profile_name }}/broad-submit.py
+++ b/{{ cookiecutter.profile_name }}/broad-submit.py
@@ -14,7 +14,7 @@ __author__ = "Lucas van Dijk <lvandijk@broadinstitute.org>"
 
 # Whether we're on UGER or UGES
 CLUSTER_TYPE = "{{ cookiecutter.cluster_name }}"
-DOTKITS = " {{ cookiecutter.dotkits}} "
+DOTKITS = "{{ cookiecutter.dotkits}}"
 
 dependencies = sys.argv[1:-1]
 jobscript = sys.argv[-1]

--- a/{{ cookiecutter.profile_name }}/broad-submit.py
+++ b/{{ cookiecutter.profile_name }}/broad-submit.py
@@ -14,6 +14,7 @@ __author__ = "Lucas van Dijk <lvandijk@broadinstitute.org>"
 
 # Whether we're on UGER or UGES
 CLUSTER_TYPE = "{{ cookiecutter.cluster_name }}"
+DOTKITS = " {{ cookiecutter.dotkits}} "
 
 dependencies = sys.argv[1:-1]
 jobscript = sys.argv[-1]
@@ -39,6 +40,7 @@ threads = job.get('threads', 1)
 project = cluster_conf.get('project', 'broad')
 queue = cluster_conf.get('queue', '')
 runtime = cluster_conf.get('runtime', "")
+using_r_dotkit = 'R-' in DOTKITS
 
 # -terse flag makes sure qsub only outputs job ID to stdout
 # -r signals that jobs may be restarted in cases of *cluster* crashes
@@ -74,6 +76,10 @@ if mem_mb:
 
 if runtime:
     command.extend(['-l', 'h_rt={}'.format(runtime)])
+
+# R dotkits aren't yet avaiable on RedHat7 machines, so request RedHat6
+if using_r_dotkit:
+    command.extend(['-l', 'os=RedHat6'])
 
 if dependencies:
     command.extend(['-hold_jid', ",".join(dependencies)])


### PR DESCRIPTION
Adds an extra Cookiecutter variable `dotkits` so the user can explicitly define them.

Currently Broad RedHat7 machines don't have the `R-*` dotkits (unlike the RedHat6 machines), so `broad-submit.py` now adds the `-l os=RedHat6` flag.